### PR TITLE
add Byteman to list of available tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,7 @@ A curated list of awesome JVM low level, performance and non-framework related s
 * [aprof](https://github.com/Devexperts/aprof) - Java memory allocation profiler.
 * [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) - Sampling CPU profiler for Java featuring AsyncGetCallTrace + perf_events.
 * [BTrace](https://github.com/jbachorik/btrace) - a safe, dynamic tracing tool for the Java platform.
+* [Byteman](http://byteman.jboss.org/) - tracing, monitoring and testing tool for Java
 * [bytestacks](https://github.com/cl4es/bytestacks) - Turn JVM bytecode execution into flame graphs. 
 * [Chronon](http://chrononsystems.com) - Record your entire java program. Replay on any machine.
 * [GCeasy](http://gceasy.io/) - Machine learning guided Garbage collection log analysis tool. Auto-detect problems in the JVM GC logs and recommend solutions to it.


### PR DESCRIPTION
HI,

I'd like to add Byteman to the list of profiler tools. It's a Java agent that supports tracing, monitoring and unit/integration testing (the latter as an extension to JUnit and TestNG). I put it under profiler tools because that's really the best place I could find.