### PR TITLE
Replace Jsoniter with DSL-JSON

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,8 @@ A curated list of awesome JVM low level, performance and non-framework related s
 * [JavaFastPFOR](https://github.com/lemire/JavaFastPFOR) - Library to compress and uncompress arrays of integers very fast.
 * [java-string-similarity](https://github.com/tdebatty/java-string-similarity) - String similarity and distance measures, including Levenshtein edit distance and sibblings, Jaro-Winkler, Longest Common Subsequence, cosine similarity etc.
 * [JCTools](http://jctools.github.io/JCTools/) - Concurrent data structures currently missing from the JDK.
-* [jsoniter](http://jsoniter.com/) - Claims to be the fastest JSON parser ever.
+* [DSL-JSON](http://github.com/ngs-doo/dsl-json) - High performance JSON library with advanced compile-time databinding.
+* [jsoniter](http://jsoniter.com/) - Claims to be the fastest JSON parser ever (copy of DSL-JSON).
 * [jOOL](https://github.com/jOOQ/jOOL) - Useful extensions to Java 8 lambdas.
 * [Koloboke](https://github.com/OpenHFT/Koloboke) - Java Collections til the last breadcrumb of memory and performance.
 * [LevelDB](https://github.com/dain/leveldb) - Rewrite (port) of LevelDB in Java.


### PR DESCRIPTION
Jsoniter is a copy of DSL-JSON and since DSL-JSON is an open source project its not really awesome to copy it's architecture + code and then claim to be the fastest ever.

Also, third party benchmarks show DSL-JSON still as the fastest library:

https://github.com/fabienrenaud/java-json-benchmark
https://github.com/kostya/benchmarks
https://github.com/eishay/jvm-serializers/