### PR TITLE
Adding awesome-ai-ml-dl: java link to the Awesome section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -339,6 +339,7 @@ A curated list of awesome JVM low level, performance and non-framework related s
 
 ## Awesome lists
 
+* [Awesome AI/ML/DL: Java](https://github.com/neomatrix369/awesome-ai-ml-dl/blob/master/details/java-jvm.md#java) Awesome Artificial Intelligence, Machine Learning and Deep Learning as we learn it. Study notes and a curated list of awesome resources of such topics.
 * [Awesome Java](https://github.com/akullpp/awesome-java/) A curated list of awesome Java frameworks, libraries and software.
 
 ## Documentation

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ A curated list of awesome JVM low level, performance and non-framework related s
     - [Runtimes](#runtimes)
     - [Virtual Machines](#virtual-machines)
 - [Resources](#resources)
+    - [Awesome lists](#awesome-lists)
     - [Communities](#communities)    
     - [Documentation](#documentation)
     - [Media](#media)
@@ -335,6 +336,10 @@ A curated list of awesome JVM low level, performance and non-framework related s
 * [Zulu](https://www.azul.com/products/zulu/) - The only certified multi-platform build of OpenJDK: Free, 100% open source Java.
 
 # Resources
+
+## Awesome lists
+
+* [Awesome Java](https://github.com/akullpp/awesome-java/) A curated list of awesome Java frameworks, libraries and software.
 
 ## Documentation
 


### PR DESCRIPTION
Adding the Java aspect of the Awesome-AI-ML-DL github repo to the Awesome lists section

Related to issue #25 